### PR TITLE
Fix: set unmute volume to audio.volume

### DIFF
--- a/src/multitrack.ts
+++ b/src/multitrack.ts
@@ -328,7 +328,7 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
       }
 
       // Unmute if cue is reached
-      const newVolume = newTime >= (track.startCue || 0) && newTime < (track.endCue || Infinity) ? 1 : 0
+      const newVolume = newTime >= (track.startCue || 0) && newTime < (track.endCue || Infinity) ? audio.volume : 0
       if (newVolume !== audio.volume) audio.volume = newVolume
     })
   }


### PR DESCRIPTION
#6 
`updatePosition` method fixes the volume setting by 1 when changing the volume, I fixed it by setting the volume to `audio.volume`.
This is my first make a pr, is this correct?