### PR TITLE
Fix safari setSinkId()  is not a function issue

### DIFF
--- a/src/multitrack.ts
+++ b/src/multitrack.ts
@@ -130,7 +130,10 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
     audio.crossOrigin = 'anonymous'
     if (track.url) audio.src = track.url
     if (track.volume !== undefined) audio.volume = track.volume
-    ;(audio as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId('default')
+
+      if ('setSinkId' in audio && typeof (audio as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId === 'function') {
+          ;(audio as HTMLAudioElement & { setSinkId: (id: string) => Promise<void> }).setSinkId('default')
+      }
 
     return new Promise<typeof audio>((resolve) => {
       if (!audio.src) return resolve(audio)


### PR DESCRIPTION
`setSinkId` is not available on Safari:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId

The multi-track now fails to work when using Safari:
[Error] Unhandled Promise Rejection: TypeError: audio.setSinkId is not a function. (In 'audio.setSinkId('default')', 'audio.setSinkId' is undefined)

This PR will check if the function exists.