### PR TITLE
feat: create multitrack with media element

### DIFF
--- a/src/multitrack.ts
+++ b/src/multitrack.ts
@@ -131,13 +131,17 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
   }
 
   private initAudio(track: TrackOptions): Promise<HTMLAudioElement> {
-    let audio = new Audio()
-    audio.crossOrigin = 'anonymous'
+    let audio: HTMLAudioElement
 
     if (track.url) {
+      audio = new Audio()
+      audio.crossOrigin = 'anonymous'
       audio.src = track.url
     } else if (track.options?.media) {
-      audio = track.options?.media
+      audio = track.options.media
+    } else {
+      audio = new Audio()
+      audio.crossOrigin = 'anonymous'
     }
 
     if (track.volume !== undefined) audio.volume = track.volume


### PR DESCRIPTION
## Short description
This pull request allows the creation of a Multitrack using the media parameter.

Resolves https://github.com/katspaugh/wavesurfer-multitrack/issues/19

 
## Implementation details
 During audio initialization, the code first checks url parameter first and if it is not present, it will then look for the media parameter. This ensures backward compatibility, as the behavior remains the same even if both url and media parameters are provided by the user.

Additionally, the code has been updated to switch from using `track.url` to `track.url || track.options?.media`. 

## How to test it
You can test it as shown below
```TypeScript
const multitrack = Multitrack.create(
  [
    {
      id: 0,
      url: '/music/mp3/drum.mp3', //your audio file
      volume: 0.5,
      startPosition: 0,
      options: {
        media: new Audio('/music/mp3/vocal.mp3'),
        height: TRACK_HEIGHT,
        waveColor: 'hsl(46, 87%, 49%)',
        progressColor: 'hsl(46, 87%, 20%)'
      }
    }
  ],
  {
    container: playerRef.current, // required!
    minPxPerSec: 5, // zoom level
    rightButtonDrag: true, // drag tracks with the right mouse button
    cursorWidth: 2,
    cursorColor: '#D72F21', 
    trackBorderColor: 'black',
    envelopeOptions: {
      lineWidth: '0',
      dragPointSize: 0
    }
  }
);
```


## Screenshots
Now it works!
<img width="1799" alt="image" src="https://github.com/katspaugh/wavesurfer-multitrack/assets/47740690/5234e651-7627-483d-9d0f-72563b4d9bb3">


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes