### PR TITLE
Add setAudioRate/getAudioRate to control playback speeds directly from the multitrack object

### DIFF
--- a/src/multitrack.ts
+++ b/src/multitrack.ts
@@ -493,11 +493,23 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
     this.audios.forEach((audio) => audio.pause())
   }
 
+  /**
+   * Gets the current playback rate of the audio tracks.
+   * @returns The playback rate of the first audio track, or 1 if no tracks exist.
+   */
   public getAudioRate(): number {
-    return (this.audios.length > 0) ? this.audios[0].playbackRate : 1
+    return this.audios.length > 0 ? this.audios[0].playbackRate : 1
   }
 
+  /**
+   * Sets the playback rate for all audio tracks to maintain synchronization.
+   * @param rate The playback rate (between 0.25 and 5.0).
+   * @throws {Error} If the rate is outside the valid range.
+   */
   public setAudioRate(rate: number) {
+    if (rate < 0.25 || rate > 5.0) {
+      throw new Error('Playback rate must be between 0.25 and 5.0')
+    }
     this.audios.forEach((audio) => {
       audio.playbackRate = rate
     })

--- a/src/multitrack.ts
+++ b/src/multitrack.ts
@@ -493,6 +493,16 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
     this.audios.forEach((audio) => audio.pause())
   }
 
+  public getAudioRate(): number {
+    return (this.audios.length > 0) ? this.audios[0].playbackRate : 1
+  }
+
+  public setAudioRate(rate: number) {
+    this.audios.forEach((audio) => {
+      audio.playbackRate = rate
+    })
+  }
+
   public isPlaying() {
     return this.audios.some((audio) => !audio.paused)
   }


### PR DESCRIPTION
Another dev on my team forked the code into our own codebase and added this feature.  It works, I'm not sure if it's the best way to do it, but I needed to get us back to using the officially released library.  For some reason the timeline stopped working when using the one brought into our repo.  Anyway, if this should be done using the wavesurfer rate control instead, I could take a look at that, but if this works, it'd be awesome to get it into a release at some point.  Currently I switched to the released library in npm and then monkey-patched these functions into the class, so we could ship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls to view and adjust the playback speed for multi-track audio, enhancing the audio experience by allowing synchronized rate adjustments across all tracks.
  - Introduced methods to retrieve and set the playback rate for audio elements, providing users with more control over audio playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->